### PR TITLE
fixing code climate score

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+exclude_patterns:
+  - "public/"
+  - "app/assets/"
+  - "db/migrate/"
+  - "doc/js/"
+  - "babel.config.js"


### PR DESCRIPTION
Code climate said there was 1 code smell in **babel.config.js**, but since this is a standard .js file, _I am setting code climate to ignore it, along with some other standard files._